### PR TITLE
Update `install-brew` process

### DIFF
--- a/Flasher.sh
+++ b/Flasher.sh
@@ -4,14 +4,11 @@
 
 function install-brew {
 
-  sudo /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)" -y
+  /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 
   brew install bash wget curl screen u-boot-tools libusb zlib pkg-config git 
-  wget https://raw.githubusercontent.com/Homebrew/homebrew-cask/cf82f0a10d08afd146e176c275a03964ae9e5866/Casks/android-platform-tools.rb
-
-  brew cask install android-platform-tools.rb
-
-  rm android-platform-tools.rb
+  
+  brew install homebrew/cask/android-platform-tools
 }
 
 #Install the C.H.I.P Tools ported for MacOS


### PR DESCRIPTION
This uses the instructions on the https://brew.sh site to install brew (without `sudo`) and uses the latest (28.0.3) `homebrew/cask/android-platform-tools` cask rather than grabbing the old 26.0.2 `android-platform-tools.rb` and having to clean it up.